### PR TITLE
Bug Fix: `delLastVisit` reports delete success when lastVisit is empty

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DelLastVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelLastVisitCommand.java
@@ -68,7 +68,7 @@ public class DelLastVisitCommand extends Command {
         Patient patientToEdit = lastShownList.get(index.getZeroBased());
 
         if (patientToEdit.getLastVisit() == null) {
-            throw new CommandException(String.format(MESSAGE_NO_LAST_VISIT,  patientToEdit.getName()));
+            throw new CommandException(String.format(MESSAGE_NO_LAST_VISIT, patientToEdit.getName()));
         }
 
         Patient editedPatient = new Patient(

--- a/src/main/java/seedu/address/logic/commands/DelLastVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelLastVisitCommand.java
@@ -23,6 +23,8 @@ public class DelLastVisitCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + '\n'
             + "Example: " + COMMAND_WORD + " 1 ";
+
+    public static final String MESSAGE_NO_LAST_VISIT = "This patient does not currently have a last visit: %1$s";
     public static final String NONE = "None";
 
     private final Index index;
@@ -64,6 +66,11 @@ public class DelLastVisitCommand extends Command {
 
         // Create a new Patient with `null` last visit
         Patient patientToEdit = lastShownList.get(index.getZeroBased());
+
+        if (patientToEdit.getLastVisit() == null) {
+            throw new CommandException(String.format(MESSAGE_NO_LAST_VISIT,  patientToEdit.getName()));
+        }
+
         Patient editedPatient = new Patient(
                 patientToEdit.getName(),
                 patientToEdit.getPhone(),
@@ -73,6 +80,7 @@ public class DelLastVisitCommand extends Command {
                 patientToEdit.getTags(),
                 patientToEdit.getMedicines()
         );
+
 
         // Update the patient in the model
         model.setPatient(patientToEdit, editedPatient);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -21,7 +21,7 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
-    public static final LastVisit EMPTY_LAST_VISIT = new LastVisit(LocalDate.parse("2025-03-01"));
+    public static final LastVisit DEFAULT_LAST_VISIT = new LastVisit(LocalDate.parse("2025-03-01"));
 
     public static final Set<Medicine> EMPTY_MEDICINES = Collections.emptySet();
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -21,30 +21,43 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
-    public static final LastVisit EMPTY_LAST_VISIT = new LastVisit(LocalDate.parse("1111-11-11"));
+    public static final LastVisit EMPTY_LAST_VISIT = new LastVisit(LocalDate.parse("2025-03-01"));
 
     public static final Set<Medicine> EMPTY_MEDICINES = Collections.emptySet();
 
     public static Patient[] getSamplePatients() {
         return new Patient[] {
-            new Patient(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_LAST_VISIT,
-                getTagSet("friends"), EMPTY_MEDICINES),
-            new Patient(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_LAST_VISIT,
-                getTagSet("colleagues", "friends"), EMPTY_MEDICINES),
+            new Patient(new Name("Tan Ah Kow"), new Phone("91234567"), new Email("ahkow88@yahoo.com"),
+                    new Address("Blk 30 Ang Mo Kio Ave 4 , #05-67"),
+                    new LastVisit(LocalDate.parse("2025-03-04")),
+                    getTagSet("diabetes", "osteoarthritis"), getMedSet("metformin", "paracetamol")),
+            new Patient(new Name("Lim Siew Eng"), new Phone("91234567"), new Email("sieweng1950@hotmail.com"),
+                    new Address("Blk 456 Tampines Ave 1 , #10-187"),
+                    new LastVisit(LocalDate.parse("2025-03-08")),
+                    getTagSet("dementia", "copd"), getMedSet("donepezil", "inhaler")),
+            new Patient(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@gmail.com"),
+                    new Address("Blk 30 Geylang Street 29, #06-40"), new LastVisit(LocalDate.parse("2025-02-27")),
+                    getTagSet("diabetes"), getMedSet("insulin")),
+            new Patient(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@yahoo.com"),
+                    new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                    new LastVisit(LocalDate.parse("2025-03-01")),
+                    getTagSet("hypertension"), getMedSet("amlodipine")),
             new Patient(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_LAST_VISIT,
-                getTagSet("neighbours"), EMPTY_MEDICINES),
+                    new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                    new LastVisit(LocalDate.parse("2025-02-25")),
+                    getTagSet("osteoporosis"), getMedSet("alendronate")),
             new Patient(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_LAST_VISIT,
-                getTagSet("family"), EMPTY_MEDICINES),
+                    new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                    new LastVisit(LocalDate.parse("2025-03-03")),
+                    getTagSet("cholesterol"), getMedSet("atorvastatin")),
             new Patient(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_LAST_VISIT,
-                getTagSet("classmates"), EMPTY_MEDICINES),
+                    new Address("Blk 47 Tampines Street 20, #17-35"),
+                    new LastVisit(LocalDate.parse("2025-03-05")),
+                    getTagSet("depression"), getMedSet("sertraline")),
             new Patient(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_LAST_VISIT,
-                getTagSet("colleagues"), EMPTY_MEDICINES)
+                    new Address("Blk 45 Aljunied Street 85, #11-31"),
+                    new LastVisit(LocalDate.parse("2025-03-07")),
+                    getTagSet("arthritis"), getMedSet("paracetamol"))
         };
     }
 


### PR DESCRIPTION
- Fix bug where `delLastVisit` reports delete success when lastVisit is empty
- Update sample patient list to suit CareConnect
Closes #140 
Closes #171 
Closes #172 