### PR TITLE
Modify medicine name validation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UnprescribeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnprescribeCommand.java
@@ -22,7 +22,7 @@ import seedu.address.model.patient.Patient;
  * and removes the specified medicine from that patient's medical record.
  */
 public class UnprescribeCommand extends Command {
-    public static final Medicine REMOVE_ALL_PLACEHOLDER = new Medicine("-");
+    public static final Medicine REMOVE_ALL_PLACEHOLDER = new Medicine("PLACEHOLDER");
     public static final String COMMAND_WORD = "unprescribe";
 
     public static final String MESSAGE_REMOVE_MED_SUCCESS = "Removed medication(s) %1$s from patient: %2$s";

--- a/src/main/java/seedu/address/logic/parser/UnprescribeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnprescribeCommandParser.java
@@ -34,7 +34,7 @@ public class UnprescribeCommandParser implements Parser<UnprescribeCommand> {
         // Parse and validate the index
         String preamble = argMultimap.getPreamble().trim();
 
-        // Check if string is empty or contains non-digit characters (format issue)
+        // Check if index is empty or contains non-digit characters (format issue)
         if (preamble.isEmpty() || !preamble.matches("-?\\d+")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnprescribeCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/model/medicine/Medicine.java
+++ b/src/main/java/seedu/address/model/medicine/Medicine.java
@@ -10,8 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Medicine {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Medicine names should only contain letters, numbers, hyphens (-), and underscores (_).";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9_-]+$";
+            "Medicine names should only contain letters, numbers, hyphens (-), and underscores (_).\n"
+            + "Medicine names cannot start with a special character.\n";
+    public static final String VALIDATION_REGEX = "^[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?$";
 
     public final String medName;
 


### PR DESCRIPTION
- Medicine name cannot start or end with a special character
- Invalid Medicine Name values will now show an error message reflecting the constraint above.